### PR TITLE
Add Load to bq package

### DIFF
--- a/bq/client.go
+++ b/bq/client.go
@@ -82,3 +82,29 @@ func (c *Client) UpdateSchema(ctx context.Context, ds bqiface.Dataset, dt *api.D
 	}, "")
 	return err
 }
+
+// Load loads data from a set of GCS uris to a BigQuery table. It overwrites the existing data in
+// the destination table. If the table name includes a partition decoration (e.g., table$YYYYMMDD),
+// it will only overwrite said partition.
+func (c *Client) Load(ctx context.Context, ds bqiface.Dataset, name string, uri ...string) error {
+	gcsRef := bigquery.NewGCSReference(uri...)
+	gcsRef.SourceFormat = bigquery.JSON
+	loader := ds.Table(name).LoaderFrom(gcsRef)
+	loader.SetLoadConfig(bqiface.LoadConfig{
+		LoadConfig: bigquery.LoadConfig{
+			WriteDisposition: bigquery.WriteTruncate,
+		},
+	})
+
+	job, err := loader.Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
+	return status.Err()
+}

--- a/bq/client_test.go
+++ b/bq/client_test.go
@@ -281,7 +281,7 @@ func TestClient_Load(t *testing.T) {
 			testingx.Must(t, err, "failed to create fake bq client")
 			c := &Client{bq}
 
-			err = c.Load(context.Background(), ds, tableID, "")
+			err = c.Load(context.Background(), ds, tableID, "gs://fake-bucket/autoload/v1/experiment/datatype/YYYY/MM/DD/*")
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Client.Load() error = %v, wantErr = %v", err, tt.wantErr)
 			}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/bigquery v1.49.0
 	cloud.google.com/go/storage v1.30.0
-	github.com/m-lab/go v0.1.63
+	github.com/m-lab/go v0.1.64
 	google.golang.org/api v0.114.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/bigquery v1.49.0
 	cloud.google.com/go/storage v1.30.0
-	github.com/m-lab/go v0.1.63-0.20230328171438-e81762c3043e
+	github.com/m-lab/go v0.1.63
 	google.golang.org/api v0.114.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/bigquery v1.49.0
 	cloud.google.com/go/storage v1.30.0
-	github.com/m-lab/go v0.1.61
+	github.com/m-lab/go v0.1.63-0.20230328171438-e81762c3043e
 	google.golang.org/api v0.114.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0P
 github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/m-lab/go v0.1.63 h1:PBaFDhnEPQhcfU5FX6HrlIKAEHIGJV4+Cgu3e2U6QMQ=
-github.com/m-lab/go v0.1.63/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
+github.com/m-lab/go v0.1.64 h1:8PpCUBlSH59YWQleXxIVZNlmz0lS8hzJWtCiOHNJcdI=
+github.com/m-lab/go v0.1.64/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0P
 github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/m-lab/go v0.1.61 h1:W30NMTQWSZG0NLRHvilD2+X9f+n4n0bx/sVlzVx86Tc=
-github.com/m-lab/go v0.1.61/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
+github.com/m-lab/go v0.1.63-0.20230328171438-e81762c3043e h1:+MMc8EVF1kzl8dwxfmDFLoqOJaMu15rK7TN/jF9zgmc=
+github.com/m-lab/go v0.1.63-0.20230328171438-e81762c3043e/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0P
 github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/m-lab/go v0.1.63-0.20230328171438-e81762c3043e h1:+MMc8EVF1kzl8dwxfmDFLoqOJaMu15rK7TN/jF9zgmc=
-github.com/m-lab/go v0.1.63-0.20230328171438-e81762c3043e/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
+github.com/m-lab/go v0.1.63 h1:PBaFDhnEPQhcfU5FX6HrlIKAEHIGJV4+Cgu3e2U6QMQ=
+github.com/m-lab/go v0.1.63/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=


### PR DESCRIPTION
This PR adds a new `Client.Load()` method to the `bq` package to load a GCS uri to a BigQuery table.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/6)
<!-- Reviewable:end -->
