### PR TITLE
Get directory paths from object names

### DIFF
--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -18,11 +18,14 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+var (
+	datePattern = `/\d{4}/[01]\d/[0123]\d`
+)
+
 const (
 	prefix           = "autoload/v1/"
 	schemaFileSuffix = ".table.json"
 	rawPrefix        = "raw_"
-	datePattern      = `/\d{4}/[01]\d/[0123]\d`
 )
 
 // Client is used to interact with Google Cloud Storage.

--- a/gcs/gcs_test.go
+++ b/gcs/gcs_test.go
@@ -152,7 +152,7 @@ func TestGetDirs(t *testing.T) {
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
 						BucketName: testBucket,
-						Name:       prefix + "experiment1/datatype1/2023/03/06/",
+						Name:       prefix + "experiment1/datatype1/2023/03/06/filename.jsonl.gz",
 					},
 				},
 			},
@@ -173,7 +173,7 @@ func TestGetDirs(t *testing.T) {
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
 						BucketName: testBucket,
-						Name:       prefix + "experiment1/datatype1/2023/03/06/",
+						Name:       prefix + "experiment1/datatype1/2023/03/06/filename.jsonl.gz",
 					},
 				},
 			},
@@ -189,12 +189,45 @@ func TestGetDirs(t *testing.T) {
 			},
 		},
 		{
-			name: "incorrect-suffix",
+			name: "success-multiple-objs-same-dir",
 			objs: []fakestorage.Object{
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
 						BucketName: testBucket,
-						Name:       prefix + "experiment1/datatype1/2023/03/06/incorrect",
+						Name:       prefix + "experiment1/datatype1/2023/03/06/",
+					},
+				},
+				{
+					ObjectAttrs: fakestorage.ObjectAttrs{
+						BucketName: testBucket,
+						Name:       prefix + "experiment1/datatype1/2023/03/06/filename.jsonl.gz",
+					},
+				},
+				{
+					ObjectAttrs: fakestorage.ObjectAttrs{
+						BucketName: testBucket,
+						Name:       prefix + "experiment1/datatype1/2023/03/06/filename2.jsonl.gz",
+					},
+				},
+			},
+			dt:    "datatype1",
+			exp:   "experiment1",
+			start: "2023/03/05",
+			end:   "2023/03/07",
+			want: []Dir{
+				{
+					Path: "gs://" + path.Join(testBucket, prefix, "experiment1/datatype1/2023/03/06/*"),
+					Date: time.Date(2023, 03, 06, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+		{
+			name: "incorrect-dir-path",
+			objs: []fakestorage.Object{
+				{
+					ObjectAttrs: fakestorage.ObjectAttrs{
+						BucketName: testBucket,
+						Name:       prefix + "incorrect-experiment/datatype1/2023/03/06/filename.jsonl.gz",
 					},
 				},
 			},
@@ -210,7 +243,7 @@ func TestGetDirs(t *testing.T) {
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
 						BucketName: testBucket,
-						Name:       prefix + "experiment1/datatype1/03/06/2023/",
+						Name:       prefix + "experiment1/datatype1/03/06/2023/filename.jsonl.gz",
 					},
 				},
 			},
@@ -226,7 +259,7 @@ func TestGetDirs(t *testing.T) {
 				{
 					ObjectAttrs: fakestorage.ObjectAttrs{
 						BucketName: testBucket,
-						Name:       prefix + "experiment1/datatype1/03/06/2023/",
+						Name:       prefix + "experiment1/datatype1/2023/03/06/filename.jsonl.gz",
 					},
 				},
 			},

--- a/gcs/gcs_test.go
+++ b/gcs/gcs_test.go
@@ -311,7 +311,7 @@ func TestGetDirs(t *testing.T) {
 	}
 }
 
-func TestGetDirs_InlivadRegex(t *testing.T) {
+func TestGetDirs_InvalidRegex(t *testing.T) {
 	server, err := fakestorage.NewServerWithOptions(fakestorage.Options{
 		InitialObjects: []fakestorage.Object{
 			{

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	cloud.google.com/go/compute v1.18.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v0.13.0 // indirect
+	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/fsouza/fake-gcs-server v1.44.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.3.0 h1:qs18EKUfHm2X9fA50Mr/M5hccg2tNnVqsiBImnyDs0g=
+github.com/deckarep/golang-set/v2 v2.3.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
This PR extracts directory paths of the from `autoload/v1/<Experiment>/<Datatype>/YYYY/MM/DD` from object names (`autoload/v1/<Experiment>/<Datatype>/YYYY/MM/DD/filename.jsonl.gz`).

It seemed like GCS already returned the pseudo-directory paths when querying for the objects under a particular prefix, but this is only the case when the directory is created through the interface.

Sample autoloaded data under [`mlab-sandbox.raw_host.nodeinfo1`](https://pantheon.corp.google.com/bigquery?referrer=search&project=mlab-sandbox&ws=!1m5!1m4!4m3!1smlab-sandbox!2sraw_host!3snodeinfo1).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/15)
<!-- Reviewable:end -->
