### PR TITLE
Add Namer interface

### DIFF
--- a/api/datatype.go
+++ b/api/datatype.go
@@ -6,14 +6,44 @@ import (
 	"github.com/m-lab/go/storagex"
 )
 
+// DatatypeOpts contains the base set of fields for an autoloaded datatype.
+type DatatypeOpts struct {
+	Name        string           // Datatype name (e.g., "ndt7").
+	Experiment  string           // Experiment name (e.g., "ndt").
+	Location    string           // Bucket location (e.g., "us-east").
+	Schema      []byte           // Contents of schema file in GCS.
+	UpdatedTime time.Time        // Last time the schema was updated in GCS.
+	Bucket      *storagex.Bucket // GCS Bucket.
+}
+
+// Namer provides the appropriate naming conventions for a Datatype.
+type Namer interface {
+	Dataset() string
+	Table() string
+	ViewDataset() string
+	ViewTable() string
+}
+
 // Datatype defines an individual datatype whose existence is denoted
 // by a schema file under the path `autoload/v1/tables/<Experiment>/<Datatype>.table.json`
 // within a GCS bucket.
 type Datatype struct {
-	Name        string           // Datatype name (e.g., "ndt7")
-	Experiment  string           // Experiment name (e.g., "ndt")
-	Location    string           // Bucket location (e.g., "us-east")
-	Schema      []byte           // Contents of schema file in GCS.
-	UpdatedTime time.Time        // Last time the schema was updated in GCS.
-	Bucket      *storagex.Bucket // GCS Bucket.
+	DatatypeOpts
+	Namer
+}
+
+// NewMlabDatatype returns a new Datatype with an MlabNamer.
+func NewMlabDatatype(opts DatatypeOpts) *Datatype {
+	return &Datatype{
+		DatatypeOpts: opts,
+		Namer:        NewMlabNamer(opts.Name, opts.Experiment),
+	}
+}
+
+// NewThirdPartyDatatype returns a new Datatype with a ThirdPartyNamer.
+func NewThirdPartyDatatype(opts DatatypeOpts, project string) *Datatype {
+	return &Datatype{
+		DatatypeOpts: opts,
+		Namer:        NewThirdPartyNamer(opts.Name, opts.Experiment, project),
+	}
 }

--- a/api/datatype_test.go
+++ b/api/datatype_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/m-lab/go/storagex"
+)
+
+var (
+	opts = DatatypeOpts{
+		Name:        "datatype",
+		Experiment:  "experiment",
+		Location:    "US",
+		Schema:      []byte{},
+		UpdatedTime: time.Time{},
+		Bucket:      &storagex.Bucket{},
+	}
+)
+
+func TestNewMlabDatatype(t *testing.T) {
+	want := &Datatype{
+		DatatypeOpts: opts,
+		Namer:        NewMlabNamer(opts.Name, opts.Experiment),
+	}
+
+	got := NewMlabDatatype(opts)
+	if !cmp.Equal(got, want, cmpopts.IgnoreUnexported(storagex.Bucket{}, storage.BucketHandle{})) {
+		t.Errorf("NewMlabDatatype() = %v, want %v", got, want)
+	}
+}
+
+func TestNewThirdPartyDatatype(t *testing.T) {
+	want := &Datatype{
+		DatatypeOpts: opts,
+		Namer:        NewThirdPartyNamer(opts.Name, opts.Experiment, "project"),
+	}
+
+	got := NewThirdPartyDatatype(opts, "project")
+	if !cmp.Equal(got, want, cmpopts.IgnoreUnexported(storagex.Bucket{}, storage.BucketHandle{})) {
+		t.Errorf("NewThirdPartyDatatype() = %v, want %v", got, want)
+	}
+}

--- a/api/mlab_namer.go
+++ b/api/mlab_namer.go
@@ -1,0 +1,40 @@
+package api
+
+const (
+	rawPrefix = "raw_"
+	rawSuffix = "_raw"
+)
+
+// NewMlabNamer returns a new instance of MlabNamer.
+func NewMlabNamer(dt, exp string) *MlabNamer {
+	return &MlabNamer{
+		Datatype:   dt,
+		Experiment: exp,
+	}
+}
+
+// MlabNamer provides the naming conventions for M-Lab datatypes.
+type MlabNamer struct {
+	Datatype   string // Datatype name.
+	Experiment string // Experiment name.
+}
+
+// Dataset name (e.g., "raw_ndt").
+func (m *MlabNamer) Dataset() string {
+	return rawPrefix + m.Experiment
+}
+
+// Table name (e.g., "ndt7").
+func (m *MlabNamer) Table() string {
+	return m.Datatype
+}
+
+// ViewDataset name (e.g., "ndt_raw").
+func (m *MlabNamer) ViewDataset() string {
+	return m.Experiment + rawSuffix
+}
+
+// ViewTable name (e.g., "ndt7").
+func (m *MlabNamer) ViewTable() string {
+	return m.Datatype
+}

--- a/api/mlab_namer_test.go
+++ b/api/mlab_namer_test.go
@@ -1,0 +1,147 @@
+package api
+
+import "testing"
+
+func TestMlabNamer_Dataset(t *testing.T) {
+	tests := []struct {
+		name       string
+		datatype   string
+		experiment string
+		want       string
+	}{
+		{
+			name:       "sample",
+			datatype:   "datatype",
+			experiment: "experiment",
+			want:       "raw_experiment",
+		},
+		{
+			name:       "ndt",
+			datatype:   "ndt7",
+			experiment: "ndt",
+			want:       "raw_ndt",
+		},
+		{
+			name:       "host",
+			datatype:   "nodeinfo1",
+			experiment: "host",
+			want:       "raw_host",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMlabNamer(tt.datatype, tt.experiment)
+			if got := m.Dataset(); got != tt.want {
+				t.Errorf("MlabNamer.Dataset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMlabNamer_Table(t *testing.T) {
+	tests := []struct {
+		name       string
+		datatype   string
+		experiment string
+		want       string
+	}{
+		{
+			name:       "sample",
+			datatype:   "datatype",
+			experiment: "experiment",
+			want:       "datatype",
+		},
+		{
+			name:       "ndt",
+			datatype:   "ndt7",
+			experiment: "ndt",
+			want:       "ndt7",
+		},
+		{
+			name:       "host",
+			datatype:   "nodeinfo1",
+			experiment: "host",
+			want:       "nodeinfo1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMlabNamer(tt.datatype, tt.experiment)
+			if got := m.Table(); got != tt.want {
+				t.Errorf("MlabNamer.Table() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMlabNamer_ViewDataset(t *testing.T) {
+	tests := []struct {
+		name       string
+		datatype   string
+		experiment string
+		want       string
+	}{
+		{
+			name:       "sample",
+			datatype:   "datatype",
+			experiment: "experiment",
+			want:       "experiment_raw",
+		},
+		{
+			name:       "ndt",
+			datatype:   "ndt7",
+			experiment: "ndt",
+			want:       "ndt_raw",
+		},
+		{
+			name:       "host",
+			datatype:   "nodeinfo1",
+			experiment: "host",
+			want:       "host_raw",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMlabNamer(tt.datatype, tt.experiment)
+			if got := m.ViewDataset(); got != tt.want {
+				t.Errorf("MlabNamer.ViewDataset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMlabNamer_ViewTable(t *testing.T) {
+	tests := []struct {
+		name       string
+		datatype   string
+		experiment string
+		want       string
+	}{
+		{
+			name:       "sample",
+			datatype:   "datatype",
+			experiment: "experiment",
+			want:       "datatype",
+		},
+		{
+			name:       "ndt",
+			datatype:   "ndt7",
+			experiment: "ndt",
+			want:       "ndt7",
+		},
+		{
+			name:       "host",
+			datatype:   "nodeinfo1",
+			experiment: "host",
+			want:       "nodeinfo1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMlabNamer(tt.datatype, tt.experiment)
+			if got := m.ViewTable(); got != tt.want {
+				t.Errorf("MlabNamer.ViewTable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/thirdparty_namer.go
+++ b/api/thirdparty_namer.go
@@ -1,0 +1,44 @@
+package api
+
+import "strings"
+
+const (
+	mlabPrefix = "mlab-"
+)
+
+// NewThirdPartyNamer returns a new instance of ThirdPartyNamer.
+func NewThirdPartyNamer(dt, exp, project string) *ThirdPartyNamer {
+	return &ThirdPartyNamer{
+		Datatype:   dt,
+		Experiment: exp,
+		Project:    strings.TrimPrefix(project, mlabPrefix),
+	}
+}
+
+// ThirdPartyNamer provides the naming conventions for third-party
+// datatypes.
+type ThirdPartyNamer struct {
+	Datatype   string // Datatype name.
+	Experiment string // Experiment name.
+	Project    string // Project name.
+}
+
+// Dataset name (e.g., "experiment").
+func (tp *ThirdPartyNamer) Dataset() string {
+	return tp.Experiment
+}
+
+// Table name (e.g., "datatype").
+func (tp *ThirdPartyNamer) Table() string {
+	return tp.Datatype
+}
+
+// ViewDataset name (e.g., "project").
+func (tp *ThirdPartyNamer) ViewDataset() string {
+	return tp.Project
+}
+
+// ViewTable name (e.g., "experiment_datatype").
+func (tp *ThirdPartyNamer) ViewTable() string {
+	return tp.Experiment + "_" + tp.Datatype
+}

--- a/api/thirdparty_namer_test.go
+++ b/api/thirdparty_namer_test.go
@@ -1,0 +1,135 @@
+package api
+
+import "testing"
+
+func TestThirdPartyNamer_Dataset(t *testing.T) {
+	tests := []struct {
+		name       string
+		datatype   string
+		experiment string
+		project    string
+		want       string
+	}{
+		{
+			name:       "sample",
+			datatype:   "datatype",
+			experiment: "experiment",
+			project:    "project",
+			want:       "experiment",
+		},
+		{
+			name:       "cloudflare",
+			datatype:   "speed1",
+			experiment: "speedtest",
+			project:    "mlab-cloudflare",
+			want:       "speedtest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tp := NewThirdPartyNamer(tt.datatype, tt.experiment, tt.project)
+			if got := tp.Dataset(); got != tt.want {
+				t.Errorf("ThirdPartyNamer.Dataset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestThirdPartyNamer_Table(t *testing.T) {
+	tests := []struct {
+		name       string
+		datatype   string
+		experiment string
+		project    string
+		want       string
+	}{
+		{
+			name:       "sample",
+			datatype:   "datatype",
+			experiment: "experiment",
+			project:    "project",
+			want:       "datatype",
+		},
+		{
+			name:       "cloudflare",
+			datatype:   "speed1",
+			experiment: "speedtest",
+			project:    "mlab-cloudflare",
+			want:       "speed1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tp := NewThirdPartyNamer(tt.datatype, tt.experiment, tt.project)
+			if got := tp.Table(); got != tt.want {
+				t.Errorf("ThirdPartyNamer.Table() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestThirdPartyNamer_ViewDataset(t *testing.T) {
+	tests := []struct {
+		name       string
+		datatype   string
+		experiment string
+		project    string
+		want       string
+	}{
+		{
+			name:       "sample",
+			datatype:   "datatype",
+			experiment: "experiment",
+			project:    "project",
+			want:       "project",
+		},
+		{
+			name:       "cloudflare",
+			datatype:   "speed1",
+			experiment: "speedtest",
+			project:    "mlab-cloudflare",
+			want:       "cloudflare",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tp := NewThirdPartyNamer(tt.datatype, tt.experiment, tt.project)
+			if got := tp.ViewDataset(); got != tt.want {
+				t.Errorf("ThirdPartyNamer.ViewDataset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestThirdPartyNamer_ViewTable(t *testing.T) {
+	tests := []struct {
+		name       string
+		datatype   string
+		experiment string
+		project    string
+		want       string
+	}{
+		{
+			name:       "sample",
+			datatype:   "datatype",
+			experiment: "experiment",
+			project:    "project",
+			want:       "experiment_datatype",
+		},
+		{
+			name:       "cloudflare",
+			datatype:   "speed1",
+			experiment: "speedtest",
+			project:    "mlab-cloudflare",
+			want:       "speedtest_speed1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tp := NewThirdPartyNamer(tt.datatype, tt.experiment, tt.project)
+			if got := tp.ViewTable(); got != tt.want {
+				t.Errorf("ThirdPartyNamer.ViewTable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/bq/client.go
+++ b/bq/client.go
@@ -30,10 +30,10 @@ func (c *Client) GetDataset(ctx context.Context, name string) (bqiface.Dataset, 
 // CreateDataset creates a new dataset for the input `api.Datatype`.
 // It returns an error if the dataset already exists.
 func (c *Client) CreateDataset(ctx context.Context, dt *api.Datatype) (bqiface.Dataset, error) {
-	ds := c.Dataset(dt.Experiment)
+	ds := c.Dataset(dt.Dataset())
 	err := ds.Create(ctx, &bqiface.DatasetMetadata{
 		DatasetMetadata: bigquery.DatasetMetadata{
-			Name:     dt.Experiment,
+			Name:     dt.Dataset(),
 			Location: dt.Location,
 		},
 	})
@@ -56,9 +56,9 @@ func (c *Client) CreateTable(ctx context.Context, ds bqiface.Dataset, dt *api.Da
 		return nil, err
 	}
 
-	t := ds.Table(dt.Name)
+	t := ds.Table(dt.Table())
 	err = t.Create(ctx, &bigquery.TableMetadata{
-		Name:   dt.Name,
+		Name:   dt.Table(),
 		Schema: bqSchema,
 		TimePartitioning: &bigquery.TimePartitioning{
 			Type:                   bigquery.DayPartitioningType,
@@ -79,7 +79,7 @@ func (c *Client) UpdateSchema(ctx context.Context, ds bqiface.Dataset, dt *api.D
 		return err
 	}
 
-	t := ds.Table(dt.Name)
+	t := ds.Table(dt.Table())
 	_, err = t.Update(ctx, bigquery.TableMetadataToUpdate{
 		Schema: bqSchema,
 	}, "")

--- a/cmd/autoloader/main.go
+++ b/cmd/autoloader/main.go
@@ -40,8 +40,8 @@ func main() {
 
 	storage, err := storage.NewClient(mainCtx)
 	rtx.Must(err, "Failed to create storage client")
-	defer storage.Close()
-	gcs := gcs.NewClient(storage, bucketNames, mlabBucket)
+	defer storage.Close() 
+	gcs := gcs.NewClient(storage, bucketNames, mlabBucket, project)
 
 	bigquery, err := bigquery.NewClient(mainCtx, project)
 	rtx.Must(err, "Failed to create BigQuery client")

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -336,74 +336,67 @@ func TestClient_processDatatype(t *testing.T) {
 	}
 }
 
-// func TestClient_load(t *testing.T) {
-// 	tests := []struct {
-// 		name     string
-// 		storage  *fakeStorage
-// 		bq       *fakeBQ
-// 		dt       *api.Datatype
-// 		wantLoad int
-// 		wantErr  bool
-// 	}{
-// 		{
-// 			name: "success",
-// 			storage: &fakeStorage{
-// 				dirs: map[string][]gcs.Dir{
-// 					"datatype": {
-// 						{Path: "fake-dir-path1"},
-// 						{Path: "fake-dir-path2"},
-// 						{Path: "fake-dir-path3"},
-// 					},
-// 				},
-// 			},
-// 			bq: &fakeBQ{},
-// 			dt: &api.Datatype{
-// 				Name: "datatype",
-// 			},
-// 			wantLoad: 3,
-// 			wantErr:  false,
-// 		},
-// 		{
-// 			name: "storage-error",
-// 			storage: &fakeStorage{
-// 				dirs: map[string][]gcs.Dir{},
-// 			},
-// 			bq: &fakeBQ{},
-// 			dt: &api.Datatype{
-// 				Name: "datatype",
-// 			},
-// 			wantLoad: 0,
-// 			wantErr:  true,
-// 		},
-// 		{
-// 			name: "load-error",
-// 			storage: &fakeStorage{
-// 				dirs: map[string][]gcs.Dir{
-// 					"datatype": {{
-// 						Path: "fake-dir-path",
-// 					}},
-// 				},
-// 			},
-// 			bq: &fakeBQ{loadErr: errors.New("failed to load file")},
-// 			dt: &api.Datatype{
-// 				Name: "datatype",
-// 			},
-// 			wantLoad: 0,
-// 			wantErr:  true,
-// 		},
-// 	}
+func TestClient_load(t *testing.T) {
+	tests := []struct {
+		name     string
+		storage  *fakeStorage
+		bq       *fakeBQ
+		wantLoad int
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			storage: &fakeStorage{
+				dirs: map[string][]gcs.Dir{
+					"datatype": {
+						{Path: "fake-dir-path1"},
+						{Path: "fake-dir-path2"},
+						{Path: "fake-dir-path3"},
+					},
+				},
+			},
+			bq:       &fakeBQ{},
+			wantLoad: 3,
+			wantErr:  false,
+		},
+		{
+			name: "storage-error",
+			storage: &fakeStorage{
+				dirs: map[string][]gcs.Dir{},
+			},
+			bq:       &fakeBQ{},
+			wantLoad: 0,
+			wantErr:  true,
+		},
+		{
+			name: "load-error",
+			storage: &fakeStorage{
+				dirs: map[string][]gcs.Dir{
+					"datatype": {{
+						Path: "fake-dir-path",
+					}},
+				},
+			},
+			bq:       &fakeBQ{loadErr: errors.New("failed to load file")},
+			wantLoad: 0,
+			wantErr:  true,
+		},
+	}
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			c := NewClient(tt.storage, tt.bq)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient(tt.storage, tt.bq)
+			dt := api.NewMlabDatatype(api.DatatypeOpts{
+				Name: "datatype",
+			})
 
-// 			if err := c.load(context.Background(), nil, tt.dt, periodOpts("annually")); (err != nil) != tt.wantErr {
-// 				t.Errorf("Client.load() error = %v, wantErr = %v", err, tt.wantErr)
-// 			}
+			if err := c.load(context.Background(), nil, dt, periodOpts("annually")); (err != nil) != tt.wantErr {
+				t.Errorf("Client.load() error = %v, wantErr = %v", err, tt.wantErr)
+			}
 
-// 			if tt.bq.loadCount != tt.wantLoad {
-// 				t.Errorf("Client.load() got = %d, want = %d", tt.bq.loadCount, tt.wantLoad)
-// 			}
-// 		})
-// 	}
-// }
+			if tt.bq.loadCount != tt.wantLoad {
+				t.Errorf("Client.load() got = %d, want = %d", tt.bq.loadCount, tt.wantLoad)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new `Namer` interface and two implementations to handle the different naming conventions for M-Lab and third-party data (as outlined in the [design](https://docs.google.com/document/d/1kJ2oy5MAwYBBCq2mVOoJBjq4zU2xiEy1gRAYNoim920/edit#heading=h.51ck68m91qwb)).

This is the first step to support updating views through the autoloader.

The line count is a bit high because the uses of `api.Datatype` in the project have been updated to use the interface methods (e.g., `Dataset()`, `Table()`). I could also move that to the next PR, if it's helpful.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/16)
<!-- Reviewable:end -->
