### PR TITLE
Add a GCS project flag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
   - -c
   - |-
     sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/' \
-           -e 's/{{BQ_PROJECT}}/'${PROJECT_ID}'/' \
+           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/' \
            -e 's/{{VIEW_PROJECT}}/'$_VIEW_PROJECT'/' \
            -e 's/{{GCP_PROJECT}}/'$_GCP_PROJECT'/' \
            -e 's/{{MLAB_BUCKET}}/'$_MLAB_BUCKET'/' \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,7 +34,9 @@ steps:
   - -c
   - |-
     sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/' \
-           -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/' \
+           -e 's/{{BQ_PROJECT}}/'${PROJECT_ID}'/' \
+           -e 's/{{VIEW_PROJECT}}/'$_VIEW_PROJECT'/' \
+           -e 's/{{GCP_PROJECT}}/'$_GCP_PROJECT'/' \
            -e 's/{{MLAB_BUCKET}}/'$_MLAB_BUCKET'/' \
            -e 's/{{BUCKETS}}/'$_BUCKETS'/' \
            k8s/autoloader.yaml

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
     sed -i -e 's/{{COMMIT_SHA}}/'${COMMIT_SHA}'/' \
            -e 's/{{PROJECT_ID}}/'${PROJECT_ID}'/' \
            -e 's/{{VIEW_PROJECT}}/'$_VIEW_PROJECT'/' \
-           -e 's/{{GCP_PROJECT}}/'$_GCP_PROJECT'/' \
+           -e 's/{{GCS_PROJECT}}/'$_GCS_PROJECT'/' \
            -e 's/{{MLAB_BUCKET}}/'$_MLAB_BUCKET'/' \
            -e 's/{{BUCKETS}}/'$_BUCKETS'/' \
            k8s/autoloader.yaml

--- a/cmd/autoloader/main.go
+++ b/cmd/autoloader/main.go
@@ -17,8 +17,9 @@ import (
 
 var (
 	listenAddr          string
-	project             string
+	bqProject           string
 	viewProject         string
+	gcpProject          string
 	mlabBucket          string
 	bucketNames         flagx.StringArray
 	mainCtx, mainCancel = context.WithCancel(context.Background())
@@ -26,8 +27,9 @@ var (
 
 func init() {
 	flag.StringVar(&listenAddr, "listenaddr", ":8080", "Address to listen on")
-	flag.StringVar(&project, "project", "mlab-sandbox", "BigQuery project environment variable")
+	flag.StringVar(&bqProject, "bq-project", "mlab-sandbox", "BigQuery project environment variable")
 	flag.StringVar(&viewProject, "view-project", "mlab-sandbox", "BigQuery project for views")
+	flag.StringVar(&gcpProject, "gcp-project", "mlab-sandbox", "GCP project")
 	flag.StringVar(&mlabBucket, "mlab-bucket", "", "Archive bucket name containing data from M-Lab's platform")
 	flag.Var(&bucketNames, "buckets", "Archive bucket names in Google Cloud Storage")
 }
@@ -43,14 +45,14 @@ func main() {
 	storage, err := storage.NewClient(mainCtx)
 	rtx.Must(err, "Failed to create storage client")
 	defer storage.Close()
-	gcs := gcs.NewClient(storage, bucketNames, mlabBucket, project)
+	gcs := gcs.NewClient(storage, bucketNames, mlabBucket, gcpProject)
 
-	bqMain, err := bigquery.NewClient(mainCtx, project)
+	bqMain, err := bigquery.NewClient(mainCtx, bqProject)
 	rtx.Must(err, "Failed to create BigQuery client")
 	defer bqMain.Close()
 
 	bqView := bqMain
-	if project != viewProject {
+	if bqProject != viewProject {
 		bqView, err = bigquery.NewClient(mainCtx, viewProject)
 		rtx.Must(err, "Failed to create BigQuery view client")
 		defer bqView.Close()

--- a/cmd/autoloader/main.go
+++ b/cmd/autoloader/main.go
@@ -19,7 +19,7 @@ var (
 	listenAddr          string
 	bqProject           string
 	viewProject         string
-	gcpProject          string
+	gcsProject          string
 	mlabBucket          string
 	bucketNames         flagx.StringArray
 	mainCtx, mainCancel = context.WithCancel(context.Background())
@@ -29,7 +29,7 @@ func init() {
 	flag.StringVar(&listenAddr, "listenaddr", ":8080", "Address to listen on")
 	flag.StringVar(&bqProject, "bq-project", "mlab-sandbox", "BigQuery project environment variable")
 	flag.StringVar(&viewProject, "view-project", "mlab-sandbox", "BigQuery project for views")
-	flag.StringVar(&gcpProject, "gcp-project", "mlab-sandbox", "GCP project")
+	flag.StringVar(&gcsProject, "gcs-project", "mlab-sandbox", "GCS project")
 	flag.StringVar(&mlabBucket, "mlab-bucket", "", "Archive bucket name containing data from M-Lab's platform")
 	flag.Var(&bucketNames, "buckets", "Archive bucket names in Google Cloud Storage")
 }
@@ -45,7 +45,7 @@ func main() {
 	storage, err := storage.NewClient(mainCtx)
 	rtx.Must(err, "Failed to create storage client")
 	defer storage.Close()
-	gcs := gcs.NewClient(storage, bucketNames, mlabBucket, gcpProject)
+	gcs := gcs.NewClient(storage, bucketNames, mlabBucket, gcsProject)
 
 	bqMain, err := bigquery.NewClient(mainCtx, bqProject)
 	rtx.Must(err, "Failed to create BigQuery client")

--- a/k8s/autoloader.yaml
+++ b/k8s/autoloader.yaml
@@ -31,7 +31,9 @@ spec:
         image: gcr.io/{{PROJECT_ID}}/autoloader:{{COMMIT_SHA}}
         args:
         - -listenaddr=:8080
-        - -project={{PROJECT_ID}}
+        - -bq-project={{BQ_PROJECT}}
+        - -view-project={{VIEW_PROJECT}}
+        - -gcp-project={{GCP_PROJECT}}
         - -mlab-bucket={{MLAB_BUCKET}}
         - -buckets={{BUCKETS}}
         - -prometheusx.listen-address=:9990

--- a/k8s/autoloader.yaml
+++ b/k8s/autoloader.yaml
@@ -33,7 +33,7 @@ spec:
         - -listenaddr=:8080
         - -bq-project={{PROJECT_ID}}
         - -view-project={{VIEW_PROJECT}}
-        - -gcp-project={{GCP_PROJECT}}
+        - -gcs-project={{GCS_PROJECT}}
         - -mlab-bucket={{MLAB_BUCKET}}
         - -buckets={{BUCKETS}}
         - -prometheusx.listen-address=:9990

--- a/k8s/autoloader.yaml
+++ b/k8s/autoloader.yaml
@@ -31,7 +31,7 @@ spec:
         image: gcr.io/{{PROJECT_ID}}/autoloader:{{COMMIT_SHA}}
         args:
         - -listenaddr=:8080
-        - -bq-project={{BQ_PROJECT}}
+        - -bq-project={{PROJECT_ID}}
         - -view-project={{VIEW_PROJECT}}
         - -gcp-project={{GCP_PROJECT}}
         - -mlab-bucket={{MLAB_BUCKET}}


### PR DESCRIPTION
This PR adds a new `-gcs-project` flag to distinguish it from the `-bq-project` one. 

The `-bq-project` flag continues to be set to the current project where the autoloader is running (e.g., "mlab-oti"), while the `-gcs-project` one can be configured to a different project (e.g., "measurement-lab").

The PR also sets the `-view-project` flag, which before was only set to the default value (i.e., "mlab-sandbox").

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/20)
<!-- Reviewable:end -->
