### PR TITLE
Use "US" for the location of all datasets

### DIFF
--- a/bq/client.go
+++ b/bq/client.go
@@ -37,8 +37,9 @@ func (c *Client) CreateDataset(ctx context.Context, dt *api.Datatype) (bqiface.D
 	ds := c.Dataset(dt.Dataset())
 	err := ds.Create(ctx, &bqiface.DatasetMetadata{
 		DatasetMetadata: bigquery.DatasetMetadata{
-			Name:     dt.Dataset(),
-			Location: dt.Location,
+			Name: dt.Dataset(),
+			// TODO(github.com/m-lab/gcp-config/issues/73): Fix bucket location.
+			Location: "US",
 		},
 	})
 	return ds, err


### PR DESCRIPTION
When creating a new dataset, the autoloader uses the bucket's location (e.g., "US" or "us-central1") as the dataset's location. 

For the `archive-mlab-oti` bucket, the location is "us-central1" (single-region). But, the rest of the pipeline requires that the location of the underlying table be public-facing views be "US" (multi-region). This PR is changing the location of the datasets to always be "US".

Related to https://github.com/m-lab/gcp-config/issues/73.

Note: the existing datasets in mlab-oti will have to be deleted and the build re-run for them to be recreated with the new location.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/21)
<!-- Reviewable:end -->
