### PR TITLE
Capture load errors

### DIFF
--- a/bq/client.go
+++ b/bq/client.go
@@ -2,6 +2,7 @@ package bq
 
 import (
 	"context"
+	"errors"
 	"log"
 
 	"cloud.google.com/go/bigquery"
@@ -145,5 +146,17 @@ func (c *Client) Load(ctx context.Context, ds bqiface.Dataset, name string, uri 
 		return err
 	}
 
-	return status.Err()
+	if status.Err() != nil {
+		return jobErrors(status)
+	}
+
+	return nil
+}
+
+func jobErrors(status *bigquery.JobStatus) error {
+	var err error
+	for _, e := range status.Errors {
+		err = errors.Join(err, e)
+	}
+	return err
 }

--- a/bq/client_test.go
+++ b/bq/client_test.go
@@ -526,6 +526,7 @@ func TestClient_jobErrors(t *testing.T) {
 			if !ok {
 				t.Fatal("jobErrors() failed to cast returned error")
 			}
+
 			gotNum := len(u.Unwrap())
 			if gotNum != tt.wantNum {
 				t.Fatalf("jobErrors() gotNum = %d, wantNum = %d", gotNum, tt.wantNum)

--- a/bq/client_test.go
+++ b/bq/client_test.go
@@ -472,3 +472,46 @@ func TestClient_Load(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_jobErrors(t *testing.T) {
+	err1 := &bigquery.Error{
+		Message: "Error1",
+	}
+	err2 := &bigquery.Error{
+		Message: "Error2",
+	}
+	tests := []struct {
+		name    string
+		status  *bigquery.JobStatus
+		wantErr bool
+	}{
+		{
+			name:    "no-error",
+			status:  &bigquery.JobStatus{},
+			wantErr: false,
+		},
+		{
+			name: "one-error",
+			status: &bigquery.JobStatus{
+				Errors: []*bigquery.Error{err1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple-errors",
+			status: &bigquery.JobStatus{
+				Errors: []*bigquery.Error{err1, err2},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := jobErrors(tt.status)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("jobErrors() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds functionality to capture load errors from BQ.

Previously, `Client.Load()` was returning `status.Err()`, which returns a generic error of the form:
```
Error while reading data, error message: JSON table encountered too many errors, giving up. Rows: 11; errors: 1. Please look into the errors[] collection for more details.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/22)
<!-- Reviewable:end -->
