### PR TITLE
Use CLUSTER_NAME variable in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -43,7 +43,7 @@ steps:
     /builder/kubectl.bash apply -f k8s/autoloader.yaml
   env:
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
-  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
+  - CLOUDSDK_CONTAINER_CLUSTER=$_CLUSTER_NAME
 
 # The "hourly" job runs every 3 hours and loads the data for the last day.
 - name: gcr.io/cloud-builders/kubectl
@@ -59,7 +59,7 @@ steps:
     /builder/kubectl.bash apply -f autoloader-hourly-cronjob.yaml
   env:
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
-  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
+  - CLOUDSDK_CONTAINER_CLUSTER=$_CLUSTER_NAME
 
 # The "weekly" job runs once per month and loads the data from the last month
 # to the last day.
@@ -76,7 +76,7 @@ steps:
     /builder/kubectl.bash apply -f autoloader-weekly-cronjob.yaml
   env:
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
-  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
+  - CLOUDSDK_CONTAINER_CLUSTER=$_CLUSTER_NAME
 
 # The "monthly" job runs once per month and loads the data from the beginning of
 # the archive to the last month.
@@ -93,4 +93,4 @@ steps:
     /builder/kubectl.bash apply -f autoloader-monthly-cronjob.yaml
   env:
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
-  - CLOUDSDK_CONTAINER_CLUSTER=data-processing
+  - CLOUDSDK_CONTAINER_CLUSTER=$_CLUSTER_NAME


### PR DESCRIPTION
This change updates the cloudbuild configuration for the autoloader to use the new data-pipeline cluster (controlled through Cloud Build substitutions)

Part of:
* https://github.com/m-lab/etl/issues/1092

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/24)
<!-- Reviewable:end -->
