### PR TITLE
Add V2 namer

### DIFF
--- a/api/v2/datatype.go
+++ b/api/v2/datatype.go
@@ -1,0 +1,43 @@
+package v2
+
+import (
+	"strings"
+	"time"
+
+	"github.com/m-lab/go/storagex"
+)
+
+// DatatypeOpts contains the base set of fields for an autoloaded datatype.
+type DatatypeOpts struct {
+	Datatype     string           // Datatype name (e.g., "ndt7").
+	Experiment   string           // Experiment name (e.g., "ndt").
+	Organization string           // Organization name (e.g., "mlab").
+	Version      string           // Version (e.g., "v2").
+	Location     string           // Bucket location (e.g., "us-east").
+	Schema       []byte           // Contents of schema file in GCS.
+	UpdatedTime  time.Time        // Last time the schema was updated in GCS.
+	Bucket       *storagex.Bucket // GCS bucket.
+}
+
+// Datatype defines an individual datatype within a GCS bucket.
+type Datatype struct {
+	DatatypeOpts
+	Namer
+}
+
+// NewMlabDatatype returns a new Datatype with M-Lab naming conventions.
+func NewMlabDatatype(opts DatatypeOpts) *Datatype {
+	return &Datatype{
+		DatatypeOpts: opts,
+		Namer:        NewNamer(opts, "mlab"),
+	}
+}
+
+// NewBYODatatype returns a new Datatype with BYOS/BYOD naming conventions.
+func NewBYODatatype(opts DatatypeOpts, project string) *Datatype {
+	sp := strings.TrimPrefix(project, "mlab-")
+	return &Datatype{
+		DatatypeOpts: opts,
+		Namer:        NewNamer(opts, sp),
+	}
+}

--- a/api/v2/datatype_test.go
+++ b/api/v2/datatype_test.go
@@ -1,0 +1,46 @@
+package v2
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/m-lab/go/storagex"
+)
+
+var opts = DatatypeOpts{
+	Datatype:     "datatype",
+	Experiment:   "experiment",
+	Organization: "organization",
+	Version:      "version",
+	Location:     "location",
+	Schema:       []byte{},
+	UpdatedTime:  time.Time{},
+	Bucket:       &storagex.Bucket{},
+}
+
+func TestNewMlabDatatype(t *testing.T) {
+	want := &Datatype{
+		DatatypeOpts: opts,
+		Namer:        NewNamer(opts, "mlab"),
+	}
+
+	got := NewMlabDatatype(opts)
+	if !cmp.Equal(got, want, cmpopts.IgnoreUnexported(storagex.Bucket{}, storage.BucketHandle{})) {
+		t.Errorf("NewMlabDatatype() = %v, want %v", got, want)
+	}
+}
+
+func TestNewBYODatatype(t *testing.T) {
+	want := &Datatype{
+		DatatypeOpts: opts,
+		Namer:        NewNamer(opts, "subproject"),
+	}
+
+	got := NewBYODatatype(opts, "mlab-subproject")
+	if !cmp.Equal(got, want, cmpopts.IgnoreUnexported(storagex.Bucket{}, storage.BucketHandle{})) {
+		t.Errorf("NewBYODatatype() = %v, want %v", got, want)
+	}
+}

--- a/api/v2/namer.go
+++ b/api/v2/namer.go
@@ -1,0 +1,45 @@
+package v2
+
+import (
+	"fmt"
+)
+
+// NewNamer provides a new instance of Namer.
+func NewNamer(opts DatatypeOpts, sp string) Namer {
+	return Namer{
+		Datatype:     opts.Datatype,
+		Experiment:   opts.Experiment,
+		Organization: opts.Organization,
+		Version:      opts.Version,
+		SubProject:   sp,
+	}
+}
+
+// Namer provides the naming conventions for a datatype.
+type Namer struct {
+	Datatype     string // Datatype name (e.g., "ndt7").
+	Experiment   string // Experiment name (e.g., "ndt").
+	Organization string // Organization name (e.g., "mlab").
+	Version      string // Version (e.g., "v2").
+	SubProject   string // SubProject (e.g., "mlab", "autojoin").
+}
+
+// Dataset name (e.g., "autoload_v2_mlab_ndt").
+func (n *Namer) Dataset() string {
+	return fmt.Sprintf("autoload_%s_%s_%s", n.Version, n.Organization, n.Experiment)
+}
+
+// Table name (e.g., "ndt7_raw").
+func (n *Namer) Table() string {
+	return n.Datatype + "_raw"
+}
+
+// ViewDataset name (e.g., "mlab_v2_ndt").
+func (n *Namer) ViewDataset() string {
+	return fmt.Sprintf("%s_%s_%s", n.SubProject, n.Version, n.Experiment)
+}
+
+// ViewTable name (e.g., "ndt7_raw").
+func (n *Namer) ViewTable() string {
+	return n.Table()
+}

--- a/api/v2/namer_test.go
+++ b/api/v2/namer_test.go
@@ -1,0 +1,226 @@
+package v2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m-lab/go/storagex"
+)
+
+var (
+	moosOpts = DatatypeOpts{
+		Datatype:     "ndt7",
+		Experiment:   "ndt",
+		Organization: "mlab",
+		Version:      "v2",
+		Location:     "US",
+		Schema:       []byte{},
+		UpdatedTime:  time.Time{},
+		Bucket:       &storagex.Bucket{},
+	}
+
+	pyodOpts = DatatypeOpts{
+		Datatype:     "thirdpartydt",
+		Experiment:   "thirdpartyexp",
+		Organization: "mlab",
+		Version:      "v2",
+		Location:     "US",
+		Schema:       []byte{},
+		UpdatedTime:  time.Time{},
+		Bucket:       &storagex.Bucket{},
+	}
+
+	byosOpts = DatatypeOpts{
+		Datatype:     "ndt7",
+		Experiment:   "ndt",
+		Organization: "thirdpartyorg",
+		Version:      "v2",
+		Location:     "US",
+		Schema:       []byte{},
+		UpdatedTime:  time.Time{},
+		Bucket:       &storagex.Bucket{},
+	}
+
+	byodOpts = DatatypeOpts{
+		Datatype:     "thirdpartydt",
+		Experiment:   "thirdpartyexp",
+		Organization: "thirdpartyorg",
+		Version:      "v2",
+		Location:     "US",
+		Schema:       []byte{},
+		UpdatedTime:  time.Time{},
+		Bucket:       &storagex.Bucket{},
+	}
+)
+
+func TestNamer_Dataset(t *testing.T) {
+	tests := []struct {
+		name string
+		opts DatatypeOpts
+		sp   string
+		want string
+	}{
+		{
+			name: "moos",
+			opts: moosOpts,
+			sp:   "mlab",
+			want: "autoload_v2_mlab_ndt",
+		},
+		{
+			name: "pyod",
+			opts: pyodOpts,
+			sp:   "mlab",
+			want: "autoload_v2_mlab_thirdpartyexp",
+		},
+		{
+			name: "byos",
+			opts: byosOpts,
+			sp:   "autojoin",
+			want: "autoload_v2_thirdpartyorg_ndt",
+		},
+		{
+			name: "byod",
+			opts: byodOpts,
+			sp:   "thirdparty",
+			want: "autoload_v2_thirdpartyorg_thirdpartyexp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNamer(tt.opts, tt.sp)
+			if got := n.Dataset(); got != tt.want {
+				t.Errorf("Namer.Dataset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamer_Table(t *testing.T) {
+	tests := []struct {
+		name string
+		opts DatatypeOpts
+		sp   string
+		want string
+	}{
+		{
+			name: "moos",
+			opts: moosOpts,
+			sp:   "mlab",
+			want: "ndt7_raw",
+		},
+		{
+			name: "pyod",
+			opts: pyodOpts,
+			sp:   "mlab",
+			want: "thirdpartydt_raw",
+		},
+		{
+			name: "byos",
+			opts: byosOpts,
+			sp:   "autojoin",
+			want: "ndt7_raw",
+		},
+		{
+			name: "byod",
+			opts: byodOpts,
+			sp:   "thirdparty",
+			want: "thirdpartydt_raw",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNamer(tt.opts, tt.sp)
+			if got := n.Table(); got != tt.want {
+				t.Errorf("Namer.Table() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamer_ViewDataset(t *testing.T) {
+	tests := []struct {
+		name string
+		opts DatatypeOpts
+		sp   string
+		want string
+	}{
+		{
+			name: "moos",
+			opts: moosOpts,
+			sp:   "mlab",
+			want: "mlab_v2_ndt",
+		},
+		{
+			name: "pyod",
+			opts: pyodOpts,
+			sp:   "mlab",
+			want: "mlab_v2_thirdpartyexp",
+		},
+		{
+			name: "byos",
+			opts: byosOpts,
+			sp:   "autojoin",
+			want: "autojoin_v2_ndt",
+		},
+		{
+			name: "byod",
+			opts: byodOpts,
+			sp:   "thirdparty",
+			want: "thirdparty_v2_thirdpartyexp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNamer(tt.opts, tt.sp)
+			if got := n.ViewDataset(); got != tt.want {
+				t.Errorf("Namer.ViewDataset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamer_ViewTable(t *testing.T) {
+	tests := []struct {
+		name string
+		opts DatatypeOpts
+		sp   string
+		want string
+	}{
+		{
+			name: "moos",
+			opts: moosOpts,
+			sp:   "mlab",
+			want: "ndt7_raw",
+		},
+		{
+			name: "pyod",
+			opts: pyodOpts,
+			sp:   "mlab",
+			want: "thirdpartydt_raw",
+		},
+		{
+			name: "byos",
+			opts: byosOpts,
+			sp:   "autojoin",
+			want: "ndt7_raw",
+		},
+		{
+			name: "byod",
+			opts: byodOpts,
+			sp:   "thirdparty",
+			want: "thirdpartydt_raw",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNamer(tt.opts, tt.sp)
+			if got := n.ViewTable(); got != tt.want {
+				t.Errorf("Namer.ViewTable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a `Datatype` and a `Namer` following the [naming conventions](https://docs.google.com/document/d/1mT5QqDhkE02GuRWoRQ7JR6HuK3lIwcHng0c966lS73o/edit#heading=h.vqmtckqtltux) for the v2 Autoloader.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/26)
<!-- Reviewable:end -->
