### PR TITLE
Use api.Datatype as the object returned by the v2 package

### DIFF
--- a/api/datatype.go
+++ b/api/datatype.go
@@ -8,12 +8,14 @@ import (
 
 // DatatypeOpts contains the base set of fields for an autoloaded datatype.
 type DatatypeOpts struct {
-	Name        string           // Datatype name (e.g., "ndt7").
-	Experiment  string           // Experiment name (e.g., "ndt").
-	Location    string           // Bucket location (e.g., "us-east").
-	Schema      []byte           // Contents of schema file in GCS.
-	UpdatedTime time.Time        // Last time the schema was updated in GCS.
-	Bucket      *storagex.Bucket // GCS Bucket.
+	Name         string           // Datatype name (e.g., "ndt7").
+	Experiment   string           // Experiment name (e.g., "ndt").
+	Organization string           // Organization name (e.g., "mlab").
+	Version      string           // Version (e.g., "v2").
+	Location     string           // Bucket location (e.g., "us-east").
+	Schema       []byte           // Contents of schema file in GCS.
+	UpdatedTime  time.Time        // Last time the schema was updated in GCS.
+	Bucket       *storagex.Bucket // GCS Bucket.
 }
 
 // Namer provides the appropriate naming conventions for a Datatype.

--- a/api/v2/datatype.go
+++ b/api/v2/datatype.go
@@ -2,41 +2,22 @@ package v2
 
 import (
 	"strings"
-	"time"
 
-	"github.com/m-lab/go/storagex"
+	"github.com/m-lab/autoloader/api"
 )
 
-// DatatypeOpts contains the base set of fields for an autoloaded datatype.
-type DatatypeOpts struct {
-	Datatype     string           // Datatype name (e.g., "ndt7").
-	Experiment   string           // Experiment name (e.g., "ndt").
-	Organization string           // Organization name (e.g., "mlab").
-	Version      string           // Version (e.g., "v2").
-	Location     string           // Bucket location (e.g., "us-east").
-	Schema       []byte           // Contents of schema file in GCS.
-	UpdatedTime  time.Time        // Last time the schema was updated in GCS.
-	Bucket       *storagex.Bucket // GCS bucket.
-}
-
-// Datatype defines an individual datatype within a GCS bucket.
-type Datatype struct {
-	DatatypeOpts
-	Namer
-}
-
 // NewMlabDatatype returns a new Datatype with M-Lab naming conventions.
-func NewMlabDatatype(opts DatatypeOpts) *Datatype {
-	return &Datatype{
+func NewMlabDatatype(opts api.DatatypeOpts) *api.Datatype {
+	return &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, "mlab"),
 	}
 }
 
 // NewBYODatatype returns a new Datatype with BYOS/BYOD naming conventions.
-func NewBYODatatype(opts DatatypeOpts, project string) *Datatype {
+func NewBYODatatype(opts api.DatatypeOpts, project string) *api.Datatype {
 	sp := strings.TrimPrefix(project, "mlab-")
-	return &Datatype{
+	return &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, sp),
 	}

--- a/api/v2/datatype_test.go
+++ b/api/v2/datatype_test.go
@@ -7,11 +7,12 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/m-lab/autoloader/api"
 	"github.com/m-lab/go/storagex"
 )
 
-var opts = DatatypeOpts{
-	Datatype:     "datatype",
+var opts = api.DatatypeOpts{
+	Name:         "datatype",
 	Experiment:   "experiment",
 	Organization: "organization",
 	Version:      "version",
@@ -22,7 +23,7 @@ var opts = DatatypeOpts{
 }
 
 func TestNewMlabDatatype(t *testing.T) {
-	want := &Datatype{
+	want := &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, "mlab"),
 	}
@@ -34,7 +35,7 @@ func TestNewMlabDatatype(t *testing.T) {
 }
 
 func TestNewBYODatatype(t *testing.T) {
-	want := &Datatype{
+	want := &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, "subproject"),
 	}

--- a/api/v2/namer.go
+++ b/api/v2/namer.go
@@ -2,12 +2,14 @@ package v2
 
 import (
 	"fmt"
+
+	"github.com/m-lab/autoloader/api"
 )
 
 // NewNamer provides a new instance of Namer.
-func NewNamer(opts DatatypeOpts, sp string) Namer {
-	return Namer{
-		Datatype:     opts.Datatype,
+func NewNamer(opts api.DatatypeOpts, sp string) *Namer {
+	return &Namer{
+		Datatype:     opts.Name,
 		Experiment:   opts.Experiment,
 		Organization: opts.Organization,
 		Version:      opts.Version,

--- a/api/v2/namer_test.go
+++ b/api/v2/namer_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/autoloader/api"
 	"github.com/m-lab/go/storagex"
 )
 
 var (
-	moosOpts = DatatypeOpts{
-		Datatype:     "ndt7",
+	moosOpts = api.DatatypeOpts{
+		Name:         "ndt7",
 		Experiment:   "ndt",
 		Organization: "mlab",
 		Version:      "v2",
@@ -19,8 +20,8 @@ var (
 		Bucket:       &storagex.Bucket{},
 	}
 
-	pyodOpts = DatatypeOpts{
-		Datatype:     "thirdpartydt",
+	pyodOpts = api.DatatypeOpts{
+		Name:         "thirdpartydt",
 		Experiment:   "thirdpartyexp",
 		Organization: "mlab",
 		Version:      "v2",
@@ -30,8 +31,8 @@ var (
 		Bucket:       &storagex.Bucket{},
 	}
 
-	byosOpts = DatatypeOpts{
-		Datatype:     "ndt7",
+	byosOpts = api.DatatypeOpts{
+		Name:         "ndt7",
 		Experiment:   "ndt",
 		Organization: "thirdpartyorg",
 		Version:      "v2",
@@ -41,8 +42,8 @@ var (
 		Bucket:       &storagex.Bucket{},
 	}
 
-	byodOpts = DatatypeOpts{
-		Datatype:     "thirdpartydt",
+	byodOpts = api.DatatypeOpts{
+		Name:         "thirdpartydt",
 		Experiment:   "thirdpartyexp",
 		Organization: "thirdpartyorg",
 		Version:      "v2",
@@ -56,7 +57,7 @@ var (
 func TestNamer_Dataset(t *testing.T) {
 	tests := []struct {
 		name string
-		opts DatatypeOpts
+		opts api.DatatypeOpts
 		sp   string
 		want string
 	}{
@@ -99,7 +100,7 @@ func TestNamer_Dataset(t *testing.T) {
 func TestNamer_Table(t *testing.T) {
 	tests := []struct {
 		name string
-		opts DatatypeOpts
+		opts api.DatatypeOpts
 		sp   string
 		want string
 	}{
@@ -142,7 +143,7 @@ func TestNamer_Table(t *testing.T) {
 func TestNamer_ViewDataset(t *testing.T) {
 	tests := []struct {
 		name string
-		opts DatatypeOpts
+		opts api.DatatypeOpts
 		sp   string
 		want string
 	}{
@@ -185,7 +186,7 @@ func TestNamer_ViewDataset(t *testing.T) {
 func TestNamer_ViewTable(t *testing.T) {
 	tests := []struct {
 		name string
-		opts DatatypeOpts
+		opts api.DatatypeOpts
 		sp   string
 		want string
 	}{


### PR DESCRIPTION
This PR updates the v2 package to turn a `api.Datatype` object, so that the same object type can be used in the [handler](https://github.com/m-lab/autoloader/blob/main/handler/handler.go#L26) interfaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/28)
<!-- Reviewable:end -->
