### PR TITLE
Only reprocess the last 12 months of data in 'annually' job

### DIFF
--- a/handler/opts.go
+++ b/handler/opts.go
@@ -54,6 +54,7 @@ func periodOpts(p string) *LoadOptions {
 	tomorrow := now.AddDate(0, 0, 1).Format(timex.YYYYMMDDWithSlash)
 	yesterday := now.AddDate(0, 0, -1).Format(timex.YYYYMMDDWithSlash)
 	month := now.AddDate(0, -1, 0).Format(timex.YYYYMMDDWithSlash)
+	year := now.AddDate(-1, 0, 0).Format(timex.YYYYMMDDWithSlash)
 
 	switch p {
 	case "daily":
@@ -61,7 +62,7 @@ func periodOpts(p string) *LoadOptions {
 	case "monthly":
 		return &LoadOptions{month, yesterday, p}
 	case "annually":
-		return &LoadOptions{start, month, p}
+		return &LoadOptions{year, month, p}
 	case "everything":
 		return &LoadOptions{start, tomorrow, p}
 	}

--- a/handler/opts_test.go
+++ b/handler/opts_test.go
@@ -93,7 +93,7 @@ func Test_periodOpts(t *testing.T) {
 			name: "annually",
 			p:    "annually",
 			want: &LoadOptions{
-				start,
+				now.AddDate(-1, 0, 0).Format(timex.YYYYMMDDWithSlash),
 				now.AddDate(0, -1, 0).Format(timex.YYYYMMDDWithSlash),
 				"annually",
 			},


### PR DESCRIPTION
This PR modifies the start date of the "annually" load option (run once/month) to only reprocess the last 12 months of data.

The "everything" load option can still reprocess the full history as needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/34)
<!-- Reviewable:end -->
