### PR TITLE
Add a request timeout for autoloader jobs

### DIFF
--- a/k8s/autoloader-cronjob.yaml.template
+++ b/k8s/autoloader-cronjob.yaml.template
@@ -17,3 +17,4 @@ spec:
             args:
             - wget
             - http://autoloader-service:8080/{{VERSION}}/load?period={{LOAD_PERIOD}}
+            - timeout=86400


### PR DESCRIPTION
This PR adds a request timeout of 1 day (86400 seconds) for autoloader jobs. 

By default, there is a 900 second (15 minute) timeout. This timeout is not enough for "annually" jobs, which load the data for the last year.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/35)
<!-- Reviewable:end -->
