### PR TITLE
Fix wget -timeout

### DIFF
--- a/k8s/autoloader-cronjob.yaml.template
+++ b/k8s/autoloader-cronjob.yaml.template
@@ -17,4 +17,4 @@ spec:
             args:
             - wget
             - http://autoloader-service:8080/{{VERSION}}/load?period={{LOAD_PERIOD}}
-            - timeout=86400
+            - -timeout=86400

--- a/k8s/autoloader-cronjob.yaml.template
+++ b/k8s/autoloader-cronjob.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: autoloader-{{FREQUENCY}}-cronjob
+  name: autoloader-{{FREQUENCY}}-cronjo
 spec:
   schedule: {{CRON_SCHEDULE}}
   concurrencyPolicy: Forbid

--- a/k8s/autoloader-cronjob.yaml.template
+++ b/k8s/autoloader-cronjob.yaml.template
@@ -15,6 +15,5 @@ spec:
           - name: busybox
             image: busybox
             args:
-            - wget
+            - wget --timeout=86400
             - http://autoloader-service:8080/{{VERSION}}/load?period={{LOAD_PERIOD}}
-            - -timeout=86400

--- a/k8s/autoloader-cronjob.yaml.template
+++ b/k8s/autoloader-cronjob.yaml.template
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: autoloader-{{FREQUENCY}}-cronjo
+  name: autoloader-{{FREQUENCY}}-cronjob
 spec:
   schedule: {{CRON_SCHEDULE}}
   concurrencyPolicy: Forbid
@@ -15,5 +15,6 @@ spec:
           - name: busybox
             image: busybox
             args:
-            - wget --timeout=86400
+            - wget
+            - --timeout=86400
             - http://autoloader-service:8080/{{VERSION}}/load?period={{LOAD_PERIOD}}


### PR DESCRIPTION
This PR adds a missing dash to the `timeout` flag for the cornjob command.

```
$ kubectl logs autoloader-hourly-cronjob-28607940-9gvs7
Connecting to autoloader-service:8080 (10.167.255.167:8080)
saving to 'load?period=daily'
'load?period=daily' saved
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/36)
<!-- Reviewable:end -->
