### PR TITLE
Log autoload errors

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -71,6 +71,7 @@ func (c *Client) Load(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(errs) != 0 {
+		log.Printf("autoload errors:\n%s", strings.Join(errs, "\n"))
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(strings.Join(errs, "\n")))
 		return


### PR DESCRIPTION
These errors were returned via the response body, but not logged. The script invoking autoloader periodically does not output the response body, so they were effectively invisible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/40)
<!-- Reviewable:end -->
