### PR TITLE
Do not update views on v1 datatypes

### DIFF
--- a/api/datatype.go
+++ b/api/datatype.go
@@ -32,6 +32,7 @@ type Namer interface {
 type Datatype struct {
 	DatatypeOpts
 	Namer
+	UpdateView bool
 }
 
 // NewMlabDatatype returns a new Datatype with an MlabNamer.

--- a/api/datatype.go
+++ b/api/datatype.go
@@ -32,6 +32,8 @@ type Namer interface {
 type Datatype struct {
 	DatatypeOpts
 	Namer
+	// UpdateView indicates whether the view should be updated in case the schema
+	// changes.
 	UpdateView bool
 }
 

--- a/api/v2/datatype.go
+++ b/api/v2/datatype.go
@@ -11,6 +11,7 @@ func NewMlabDatatype(opts api.DatatypeOpts) *api.Datatype {
 	return &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, "mlab"),
+		UpdateSchema: true,
 	}
 }
 
@@ -20,5 +21,6 @@ func NewBYODatatype(opts api.DatatypeOpts, project string) *api.Datatype {
 	return &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, sp),
+		UpdateSchema: true,
 	}
 }

--- a/api/v2/datatype.go
+++ b/api/v2/datatype.go
@@ -11,7 +11,7 @@ func NewMlabDatatype(opts api.DatatypeOpts) *api.Datatype {
 	return &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, "mlab"),
-		UpdateSchema: true,
+		UpdateView:   true,
 	}
 }
 
@@ -21,6 +21,6 @@ func NewBYODatatype(opts api.DatatypeOpts, project string) *api.Datatype {
 	return &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, sp),
-		UpdateSchema: true,
+		UpdateView:   true,
 	}
 }

--- a/api/v2/datatype_test.go
+++ b/api/v2/datatype_test.go
@@ -26,6 +26,7 @@ func TestNewMlabDatatype(t *testing.T) {
 	want := &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, "mlab"),
+		UpdateView:   true,
 	}
 
 	got := NewMlabDatatype(opts)
@@ -38,6 +39,7 @@ func TestNewBYODatatype(t *testing.T) {
 	want := &api.Datatype{
 		DatatypeOpts: opts,
 		Namer:        NewNamer(opts, "subproject"),
+		UpdateView:   true,
 	}
 
 	got := NewBYODatatype(opts, "mlab-subproject")

--- a/bq/client.go
+++ b/bq/client.go
@@ -93,6 +93,10 @@ func (c *Client) UpdateSchema(ctx context.Context, ds bqiface.Dataset, dt *api.D
 		return err
 	}
 
+	if !dt.UpdateView {
+		return nil
+	}
+
 	return c.updateView(ctx, dt, bqSchema)
 }
 


### PR DESCRIPTION
Views for v1 datatypes are created by etl-schema. When etl-schema creates a view, all fields are NULLABLE. If autoloader tries to subsequently update a view created by etl-schema, it'll fail. After discussing with the team, we preferred to keep v1 datatypes views in etl-schema.

This change introduces an `UpdateView` field to indicate whether the view should be updated, and sets it to `true` only for v2 datatypes.

FYI @cristinaleonr

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autoloader/41)
<!-- Reviewable:end -->
